### PR TITLE
Only run verification on release config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
     # The SDK version used to compile your project
     - android-23
 
-script: ./gradlew build lint findbugs test
+script: ./gradlew assembleRelease testReleaseUnitTest lintRelease findbugs
 
 after_failure:
 - cat app/build/reports/findbugs/findbugs.html


### PR DESCRIPTION
There is no difference between the release and debug
configurations, and running both only increases the
duration of the Travis-CI build. Change to only
run the release config to reduce time.