### PR TITLE
Build debug target using proguard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,10 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
     lintOptions {
         disable "MissingTranslation"


### PR DESCRIPTION
This is to allow the debug build to be similar to
the release build, as to not miss issues
relating to using proguard.